### PR TITLE
feat: support for partial vacation days

### DIFF
--- a/flextime/flextime.py
+++ b/flextime/flextime.py
@@ -71,8 +71,8 @@ def has_tag(object, wantedTag):
 
 def calc_days(body, working_hours_per_day):
     totals = dict()
-    vaccation = 0;
-    vaccation_acc = datetime.timedelta();
+    vacation = 0;
+    vacation_acc = datetime.timedelta();
     j = json.loads(body)
     for object in j:
         start = datetime.datetime.strptime(object["start"], DATEFORMAT)
@@ -91,13 +91,13 @@ def calc_days(body, working_hours_per_day):
             tracked = datetime.timedelta(seconds=0)
 
         if (has_tag(object, VACATION_MARKER_TAG)):
-            # for vaccation don't add an entry in the totals array, only increase vaccation count,
+            # for vacation don't add an entry in the totals array, only increase vacation count,
             # works by accumulating tracked time until reaching a breakpoint of one complete working
-            # day, at which point the vaccation count is incremented
-            vaccation_acc += tracked
-            if vaccation_acc >= datetime.timedelta(hours=working_hours_per_day):
-                vaccation += 1
-                vaccation_acc = datetime.timedelta()
+            # day, at which point the vacation count is incremented
+            vacation_acc += tracked
+            if vacation_acc >= datetime.timedelta(hours=working_hours_per_day):
+                vacation += 1
+                vacation_acc = datetime.timedelta()
             continue;
 
         if day in totals:
@@ -106,7 +106,7 @@ def calc_days(body, working_hours_per_day):
             totals[day] = tracked
 
 
-    return totals, vaccation
+    return totals, vacation
 
 def get_header(start, end):
     return [
@@ -178,7 +178,7 @@ def calcFlexTime(input_stream):
     flextime_baseline = int(flextime_start_hours * 60 * 60)
 
     # Sum the seconds tracked by day.
-    totals, vaccation = calc_days(body, working_hours_per_day)
+    totals, vacation = calc_days(body, working_hours_per_day)
 
     date_width = 10 # length of day string
  
@@ -227,8 +227,8 @@ def calcFlexTime(input_stream):
     output.append("Vacation:")
     underline(output,color_config)
     output.append("{:{width}} {:10} ".format("Total (this year)", vacation_total, width=20))
-    output.append("{:{width}} {:10} ".format("Taken in period", vaccation, width=20))
-    output.append("{:{width}} {:10}*".format("Left*", vacation_total - vaccation, width=20))
+    output.append("{:{width}} {:10} ".format("Taken in period", vacation, width=20))
+    output.append("{:{width}} {:10}*".format("Left*", vacation_total - vacation, width=20))
     output.append("")
     output.append("*Left also includes vacation taken in periods that are not shown in this report.")
     


### PR DESCRIPTION
This is a quick change I made to solve for my case where most of my vacation days are split up into two entries. My suggestion is just to increment vacation count each time the tracked time delta reaches a full working day.